### PR TITLE
Follow proxy flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Comparing 50 source files for each address, on multiple networks and doing it by
 
 #### Verify a contract against a local project
 
-Running `mirror verify` shows the diff between the given address(es) and the source files on a local directory. By default it targets Ethereum Mainnet and the root path is the current directory. In certain networks, the API is not required.
+Running `mirror verify` shows the diff between the given address(es) and the source files on a local directory. By default it targets Ethereum Mainnet and the root path is the current directory. In certain networks, the API key is not required.
 
 ```sh
 mirror verify --api-key <ETHERSCAN_API_KEY> 0x1234... 0x2345...
@@ -64,7 +64,7 @@ mirror verify \
 
 #### Diff'ing two on-chain contracts
 
-Running `mirror diff` shows the diff between two on-chain contracts verified on Etherscan. By default it targets Ethereum Mainnet and in certain networks, the API is not required.
+Running `mirror diff` shows the diff between two on-chain contracts verified on Etherscan. By default it targets Ethereum Mainnet and in certain networks, the API key is not required.
 
 ```sh
 mirror diff \
@@ -133,6 +133,19 @@ mirror diff --follow-proxy 0x1234... 0x5678...
 | Flag | Alias | Description | Default |
 | --- | --- | --- | --- |
 | `--output` | `-o` | Destination folder for cloned contract. | `./<ContractName>` |
+
+### Remappings
+
+For cases where the local folder uses different paths than the ones verified on Etherscan, you can pass a remappings file. It follows the format used by Foundry:
+
+```sh
+# dependency-name = relative-path
+@aragon/osx/=lib/osx/packages/contracts/src/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+@openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
+```
+
+If the project folder already has a `remappings.txt` file, it will be used automatically.
 
 ### Using with Deno
 

--- a/README.md
+++ b/README.md
@@ -94,17 +94,45 @@ This will:
 
 Paths like `@openzeppelin/...` or `node_modules/@openzeppelin/...` are automatically transformed to `lib/@openzeppelin/...` for Foundry compatibility.
 
+#### Working with proxy contracts
+
+Use `--follow-proxy` to resolve a proxy contract to its implementation. This works with all commands:
+
+```sh
+# Clone the implementation behind a proxy
+mirror clone --follow-proxy 0x1234...
+
+# Verify the implementation source code
+mirror verify --follow-proxy 0x1234...
+
+# Diff two proxy implementations
+mirror diff --follow-proxy 0x1234... 0x5678...
+```
+
 ### Options
+
+**Global options** (apply to all commands):
 
 | Flag | Alias | Description | Default |
 | --- | --- | --- | --- |
 | `--api-key` | `-k` | Your Etherscan API key. Required for most chains. | |
 | `--chain-id` | `-i` | The chain ID of the target network. | `1` (Ethereum Mainnet) |
-| `--source-root` | `-r` | The root path of the source code folder (verify only). | `.` (current directory) |
-| `--remappings` | `-m` | Path to the `remappings.txt` file (verify only). | `remappings.txt` in the source root |
-| `--output` | `-o` | Destination folder for cloned contract (clone only). | `./<ContractName>` |
+| `--follow-proxy` | `-f` | Resolve proxy contracts to their implementation. | |
 | `--version` | | Show the version number. | |
 | `--help` | | Show the help message. | |
+
+**Verify options**:
+
+| Flag | Alias | Description | Default |
+| --- | --- | --- | --- |
+| `--source-root` | `-r` | The root path of the source code folder. | `.` (current directory) |
+| `--remappings` | `-m` | Path to the `remappings.txt` file. | `remappings.txt` in the source root |
+
+**Clone options**:
+
+| Flag | Alias | Description | Default |
+| --- | --- | --- | --- |
+| `--output` | `-o` | Destination folder for cloned contract. | `./<ContractName>` |
 
 ### Using with Deno
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ For cases where the local folder uses different paths than the ones verified on 
 
 If the project folder already has a `remappings.txt` file, it will be used automatically.
 
+NOTE: Mirror assumes that you are verifying a project from the same repo that was used to deploy it. Verifying a contract against a local source that lives in a different repo (different path structure), chances are that many explicit remappings will be needed. 
+
 ### Using with Deno
 
 If you have Deno installed, you can run EVM Mirror directly from the source code.

--- a/lib/blockscout.ts
+++ b/lib/blockscout.ts
@@ -38,14 +38,6 @@ function parseVerifiedSources(
     throw new Error("The contract is not verified or does not exist");
   }
 
-  if (apiResult.implementations?.length) {
-    console.log(
-      gray(
-        `[Implementation at ${bold(apiResult.implementations[0].address)}]\n`,
-      ),
-    );
-  }
-
   const result: ContractSourcesWithMeta = {
     address: contractAddress,
     sources: {

--- a/lib/blockscout.ts
+++ b/lib/blockscout.ts
@@ -61,6 +61,11 @@ function parseVerifiedSources(
     },
   };
 
+  // Include proxy info if available
+  if (apiResult.implementations?.length) {
+    result.proxy = { implementation: apiResult.implementations[0].address };
+  }
+
   for (const dependency of apiResult.additional_sources) {
     result.sources[dependency.file_path] = dependency.source_code;
   }

--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -17,7 +17,7 @@ export function getArguments() {
       "output",
       "o",
     ],
-    boolean: ["h", "v"],
+    boolean: ["h", "v", "follow-proxy", "f"],
     alias: {
       r: "sourceRoot",
       i: "chainId",
@@ -26,9 +26,11 @@ export function getArguments() {
       v: "version",
       h: "help",
       o: "output",
+      f: "followProxy",
       "source-root": "sourceRoot",
       "chain-id": "chainId",
       "api-key": "apiKey",
+      "follow-proxy": "followProxy",
     },
   });
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,4 +1,4 @@
-export const MIRROR_VERSION = "0.13.0";
+export const MIRROR_VERSION = "0.14.0";
 
 export const DEFAULT_SOLC_VERSION = "0.8.28";
 

--- a/lib/etherscan.ts
+++ b/lib/etherscan.ts
@@ -66,6 +66,11 @@ function parseVerifiedSources(
     },
   };
 
+  // Include proxy info if available
+  if (sourceResult.Proxy === "1" && sourceResult.Implementation) {
+    result.proxy = { implementation: sourceResult.Implementation };
+  }
+
   if (sourceCode.startsWith("{{") && sourceCode.endsWith("}}")) {
     // Standard JSON-Input format
     sourceCode = sourceCode.slice(1, -1); // Remove the outer braces

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,6 +18,9 @@ export type CompilerMeta = {
 
 export type ContractSourcesWithMeta = ContractSources & {
   meta: CompilerMeta;
+  proxy?: {
+    implementation: string;
+  };
 };
 
 export type Remappings = Record<string, string>;

--- a/main.ts
+++ b/main.ts
@@ -1,7 +1,8 @@
-import { green, red, yellow } from "jsr:@std/fmt/colors";
+import { gray, green, red, yellow } from "jsr:@std/fmt/colors";
 import { join } from "jsr:@std/path";
 import { CliArguments, getArguments } from "./lib/cli.ts";
 import { getNetworkData } from "./lib/networks.ts";
+import { Network } from "./lib/types.ts";
 import { fetchSources as fetchEtherscanSources } from "./lib/etherscan.ts";
 import { fetchSources as fetchBlockscoutSources } from "./lib/blockscout.ts";
 import {
@@ -54,11 +55,52 @@ async function main() {
   }
 }
 
+// Helpers
+
+/**
+ * Fetches contract sources, optionally resolving proxy to implementation.
+ */
+async function fetchContractSources(
+  address: string,
+  networkData: Network,
+  apiKey: string | undefined,
+  followProxy: boolean,
+) {
+  const fetcher =
+    networkData.type === "etherscan"
+      ? fetchEtherscanSources
+      : fetchBlockscoutSources;
+
+  const contractInfo = await fetcher(address, networkData, apiKey);
+
+  if (!followProxy) {
+    return contractInfo;
+  }
+
+  if (!contractInfo.proxy?.implementation) {
+    console.log(gray(`Note: ${address} is not a proxy, nothing to follow.\n`));
+    return contractInfo;
+  }
+
+  console.log(
+    gray(
+      `Following proxy to implementation: ${contractInfo.proxy.implementation}\n`,
+    ),
+  );
+  return await fetcher(contractInfo.proxy.implementation, networkData, apiKey);
+}
+
 // Handlers
 
 async function verifyContractsCmd(args: CliArguments) {
   const contracts = args._.slice(1);
-  let { chainId, apiKey, sourceRoot, remappings: remappingsFile } = args;
+  let {
+    chainId,
+    apiKey,
+    sourceRoot,
+    remappings: remappingsFile,
+    followProxy,
+  } = args;
 
   if (!chainId) chainId = "1";
   if (!sourceRoot) sourceRoot = ".";
@@ -86,13 +128,14 @@ async function verifyContractsCmd(args: CliArguments) {
   const remappings = await loadRemappings(remappingsFile!);
 
   let hasIssues = false;
-  const fetchSources =
-    networkData.type === "etherscan"
-      ? fetchEtherscanSources
-      : fetchBlockscoutSources;
 
   for (const address of contracts) {
-    const contractInfo = await fetchSources(address, networkData, apiKey);
+    const contractInfo = await fetchContractSources(
+      address,
+      networkData,
+      apiKey,
+      !!followProxy,
+    );
 
     if (Object.keys(contractInfo.sources).length === 0) {
       console.warn(yellow(`No source files were received for ${address}.`));
@@ -130,7 +173,7 @@ async function diffContractsCmd(args: CliArguments) {
   }
 
   const [addressA, addressB] = args._.slice(1);
-  let { chainId, apiKey } = args;
+  let { chainId, apiKey, followProxy } = args;
 
   if (!chainId) chainId = "1";
 
@@ -145,14 +188,18 @@ async function diffContractsCmd(args: CliArguments) {
     throw new Error("Unsupported chain ID: " + chainId);
   }
 
-  let hasIssues = false;
-  const fetchSources =
-    networkData.type === "etherscan"
-      ? fetchEtherscanSources
-      : fetchBlockscoutSources;
-
-  const contractA = await fetchSources(addressA, networkData, apiKey);
-  const contractB = await fetchSources(addressB, networkData, apiKey);
+  const contractA = await fetchContractSources(
+    addressA,
+    networkData,
+    apiKey,
+    !!followProxy,
+  );
+  const contractB = await fetchContractSources(
+    addressB,
+    networkData,
+    apiKey,
+    !!followProxy,
+  );
 
   if (Object.keys(contractA.sources).length === 0) {
     throw new Error(`No source files were received for ${contractA.address}.`);
@@ -164,9 +211,7 @@ async function diffContractsCmd(args: CliArguments) {
   printDiffResults(results);
   console.log();
 
-  if (results.some((item) => item.status !== "match")) {
-    hasIssues = true;
-  }
+  const hasIssues = results.some((item) => item.status !== "match");
 
   if (!hasIssues) {
     console.error(
@@ -179,7 +224,7 @@ async function diffContractsCmd(args: CliArguments) {
 }
 
 async function cloneContractCmd(args: CliArguments) {
-  let address = args._[1];
+  const address = args._[1];
   let { chainId, apiKey, output, followProxy } = args;
 
   if (!chainId) chainId = "1";
@@ -194,23 +239,12 @@ async function cloneContractCmd(args: CliArguments) {
     throw new Error("Unsupported chain ID: " + chainId);
   }
 
-  const fetchSources =
-    networkData.type === "etherscan"
-      ? fetchEtherscanSources
-      : fetchBlockscoutSources;
-
-  let contractInfo = await fetchSources(address, networkData, apiKey);
-
-  // Follow proxy to implementation if requested
-  if (followProxy && contractInfo.proxy?.implementation) {
-    console.log(
-      yellow(
-        `Following proxy to implementation: ${contractInfo.proxy.implementation}\n`,
-      ),
-    );
-    address = contractInfo.proxy.implementation;
-    contractInfo = await fetchSources(address, networkData, apiKey);
-  }
+  const contractInfo = await fetchContractSources(
+    address,
+    networkData,
+    apiKey,
+    !!followProxy,
+  );
 
   if (Object.keys(contractInfo.sources).length === 0) {
     throw new Error(`No source files were received for ${address}.`);
@@ -237,6 +271,7 @@ Commands:
 Options:
   -i, --chain-id       Chain ID of the network (default: 1)
   -k, --api-key        Etherscan API key
+  -f, --follow-proxy   Resolve proxy contracts to their implementation
 
 Verify options:
   -r, --source-root    Root path of the source code (default: \$PWD)
@@ -244,7 +279,6 @@ Verify options:
 
 Clone options:
   -o, --output         Destination folder (default: ./<ContractName>)
-  -f, --follow-proxy   Clone the implementation contract instead of the proxy
 
 Examples:
   mirror verify <address-1> <address-...>
@@ -252,7 +286,7 @@ Examples:
   mirror diff <address-A> <address-B>
   mirror diff <address-A> <address-B> --chain-id 10 --api-key <your-key>
   mirror clone <address>
-  mirror clone <address> --output ./my-contract --chain-id 10 --api-key <your-key>
+  mirror clone <address> --output ./my-contract --follow-proxy --api-key <your-key>
 
 Global flags:
   --version    Show version


### PR DESCRIPTION
```
Usage: mirror <command> [options] [contracts...]

Commands:
  verify     Fetch and compare contract source code from Etherscan
  diff       Show the diff between two on-chain contracts
  clone      Download verified contract source code and create a Foundry project

Options:
  -i, --chain-id       Chain ID of the network (default: 1)
  -k, --api-key        Etherscan API key
  -f, --follow-proxy   Resolve proxy contracts to their implementation
```